### PR TITLE
Fix assert that

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# Use an official OpenJDK 19 image
+FROM openjdk:19-jdk-slim
+
+# Install Maven manually
+RUN apt-get update && apt-get install -y maven
+
+# Set the working directory
+WORKDIR /app
+
+# Copy the project files
+COPY . /app
+
+# Build the project
+RUN mvn clean package
+
+# Default command
+CMD ["mvn", "clean", "install"]

--- a/src/test/java/org/example/testing/CalculatorTest.java
+++ b/src/test/java/org/example/testing/CalculatorTest.java
@@ -10,8 +10,9 @@ import java.text.MessageFormat;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Set;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+//import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
 
 public class CalculatorTest {
 


### PR DESCRIPTION
Fix issue from this screen : 
![image](https://github.com/user-attachments/assets/b50a9ea5-172c-4670-a6fe-af8a5617e9ea)


"cannot find symbol" raise because the current imported assertThat where from package : 
  _org.assertj.core.api.AssertionsForClassTypes.assertThat_ 
instead of
  _org.assertj.core.api.Assertions.*_



That why the method containsExactlyInAnyOrder could not be found.

Also adding Dockerfile in this commit.
